### PR TITLE
Skip SSL verification in Maerkische Scholle scraper

### DIFF
--- a/app/services/scraper/maerkische_scholle.rb
+++ b/app/services/scraper/maerkische_scholle.rb
@@ -2,9 +2,14 @@
 
 module Scraper
   class MaerkischeScholle
+    class SkipSSLVerificationClient
+      include HTTParty
+      default_options.update(verify: false)
+    end
+
     URL = "https://www.maerkische-scholle.de/wohnungsangebote.html"
 
-    def initialize(http_client: HTTParty)
+    def initialize(http_client: SkipSSLVerificationClient)
       self.http_client = http_client
     end
 

--- a/spec/services/scraper/maerkische_scholle_spec.rb
+++ b/spec/services/scraper/maerkische_scholle_spec.rb
@@ -55,4 +55,10 @@ RSpec.describe Scraper::MaerkischeScholle do
     expect(result.first.properties.fetch("rooms_number"))
       .to eq 2
   end
+
+  it "skips SSL verification because of 'unable to get local issuer certificate' error" do
+    http_client = Scraper::MaerkischeScholle::SkipSSLVerificationClient
+
+    expect(http_client.default_options.fetch(:verify)).to eq false
+  end
 end


### PR DESCRIPTION
SSL verification was failing with the following error: `SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate) (OpenSSL::SSL::SSLError)`